### PR TITLE
fix: get_videos() içindeki regex yüzünden bazı bölümlerde uzun gecikmeler

### DIFF
--- a/turkanime_api/objects.py
+++ b/turkanime_api/objects.py
@@ -230,7 +230,7 @@ class Bolum:
     def get_videos(self):
         self._videos = []
         # Yalnızca tek bir fansub varsa
-        if not re.search(".*birden fazla grup",self.html):
+        if "birden fazla grup" not in self.html:
             fansub = re.findall(r"</span> ([^\\<>]*)</button>.*?iframe",self.html)[0]
             vids = re.findall(r"/embed/#/url/(.*?)\?status=0\".*?</span> ([^ ]*?) ?</button>", self.html)
             vids += re.findall(r"(ajax\/videosec&b=[A-Za-z0-9]+&v=.*?)'.*?<\/span> ?(.*?)<\/button",self.html)


### PR DESCRIPTION
## Sorun
`Bolum.videos` bazı bölümlerde 2-3 saniye içinde dönerken bazılarında
45-50 saniyeye kadar çıkabiliyordu. Fansub sayısıyla, network hızıyla
veya sunucu tarafıyla ilgisi yoktu — tamamen istemci tarafında,
Python içinde harcanan bir süreydi.

## Kök neden
`get_videos()` metodundaki:
```python
if not re.search(".*birden fazla grup", self.html):
```
satırındaki baştaki `.*`, `re.search` için gereksiz (zaten stringin her
noktasından arama yapar) ama regex motorunu, "birden fazla grup" ifadesi
sayfada bulunamadığında tüm HTML'i defalarca tarayıp geri sarmaya
(backtracking) zorluyor. Klasik bir catastrophic-backtracking senaryosu.

## Değişiklik
```python
# Önce
if not re.search(".*birden fazla grup", self.html):

# Sonra
if "birden fazla grup" not in self.html:
```
Davranışta hiçbir fonksiyonel değişiklik yok, sadece performans düzeltmesi.

## Test
- `.hack//Roots` 1. Bölüm (tek fansub):
  - Öncesi: ~46 sn → Sonrası: ~1-2 sn
- `Shingeki no Kyojin` (çok fansublu):
  - Öncesi: ~3-4 sn → Sonrası: ~1-2 sn
