### PR TITLE
get_bolum_listesi() metodunda tırnak içeren başlıkların boş gelmesi çözüldü

### DIFF
--- a/turkanime_api/objects.py
+++ b/turkanime_api/objects.py
@@ -113,7 +113,7 @@ class Anime:
         """ Anime bölümlerinin [(slug,isim),] formatında listesi. """
         anime_id = self.anime_id
         src = fetch(f'/ajax/bolumler&animeId={anime_id}')
-        return re.findall(r'\/video\/(.*?)\\?".*?title=.*?"(.*?)\\?"',src)
+        return re.findall(r'\/video\/(.*?)\\?".*?title=\\?"(.*?)\\?" style=', src)
 
     # Eski get_anime_listesi methodu, geriye dönük uyumluluk için bırakıldı.
     @staticmethod


### PR DESCRIPTION
## Sorun
`get_bolum_listesi()` metodu, `"Oshi no ko"` gibi isminde tırnak işareti barındıran animelerde bölümleri yakalayamıyor ve boş sonuç döndürüyordu.

## Çözüm
Regex'i güncelleyerek sorunu çözdüm.